### PR TITLE
feat: switch to inappwebview and add custom oauth browser

### DIFF
--- a/mobile/with-flutter/lib/widgets/oauth_browser.dart
+++ b/mobile/with-flutter/lib/widgets/oauth_browser.dart
@@ -1,0 +1,214 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
+class OAuthBrowser extends StatefulWidget {
+  final String url;
+  final String providerName;
+  final String? userAgent;
+  final ValueChanged<bool> onBrowserClosed;
+
+  const OAuthBrowser({
+    super.key,
+    required this.url,
+    required this.providerName,
+    required this.onBrowserClosed,
+    this.userAgent,
+  });
+
+  @override
+  State<OAuthBrowser> createState() => _OAuthBrowserState();
+}
+
+class _OAuthBrowserState extends State<OAuthBrowser> {
+  bool _isLoading = true;
+  double _progress = 0;
+  String? _errorMessage;
+
+  Future<NavigationActionPolicy> _handleNavigationAction(
+      InAppWebViewController controller, NavigationAction action) async {
+    // Always allow navigation; we handle callback logic in onLoadStop.
+    return NavigationActionPolicy.ALLOW;
+  }
+
+  void _handleMainFrameError(InAppWebViewController controller, Uri? uri, int code, String message) {
+    setState(() {
+      _errorMessage = message;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: MediaQuery.of(context).size.height * 0.9,
+      decoration: const BoxDecoration(
+        color: Colors.black,
+        borderRadius: BorderRadius.only(
+          topLeft: Radius.circular(16),
+          topRight: Radius.circular(16),
+        ),
+      ),
+      child: Column(
+        children: [
+          AppBar(
+            leading: CloseButton(
+              onPressed: () {
+                widget.onBrowserClosed(true);
+                Navigator.of(context).pop();
+              },
+            ),
+            title: Text('Sign In with ${widget.providerName}'),
+            backgroundColor: Colors.transparent,
+            elevation: 0,
+          ),
+          Expanded(
+            child: ClipRRect(
+              borderRadius: const BorderRadius.only(
+                topLeft: Radius.circular(16),
+                topRight: Radius.circular(16),
+              ),
+              child: Stack(
+                children: [
+                  InAppWebView(
+                    initialUrlRequest: URLRequest(url: WebUri(widget.url)),
+                    initialSettings: InAppWebViewSettings(
+                      javaScriptEnabled: true,
+                      mediaPlaybackRequiresUserGesture: false,
+                      allowsInlineMediaPlayback: true,
+                      useShouldOverrideUrlLoading: true,
+                      userAgent: widget.userAgent,
+                      mixedContentMode: MixedContentMode.MIXED_CONTENT_ALWAYS_ALLOW,
+                      safeBrowsingEnabled: false,
+                    ),
+                    shouldOverrideUrlLoading: _handleNavigationAction,
+                    onLoadStart: (controller, url) {
+                      setState(() {
+                        _isLoading = true;
+                        _errorMessage = null;
+                      });
+                    },
+                    onProgressChanged: (controller, progress) {
+                      setState(() {
+                        _progress = progress / 100;
+                      });
+                    },
+                    onLoadStop: (controller, url) {
+                      setState(() {
+                        _isLoading = false;
+                      });
+
+                      final currentUrl = url?.toString() ?? '';
+                      // Detect if this is the OAuth callback URL
+                      if ((currentUrl.contains('/auth/') && currentUrl.contains('/callback')) ||
+                          RegExp(r'https://api\..*\.usecapsule\.com/').hasMatch(currentUrl)) {
+                        widget.onBrowserClosed(false);
+                        if (mounted) {
+                          Navigator.of(context).pop();
+                        }
+                      }
+                    },
+                    onReceivedError: (controller, request, error) {
+                      // Check if the error is for the main frame. If not, ignore.
+                      if (request.isForMainFrame == true) {
+                        _handleMainFrameError(
+                          controller,
+                          request.url,
+                          error.type.toNativeValue() ?? -1,
+                          error.description,
+                        );
+                      } else {
+                        // This is a subresource error; log it and ignore.
+                        debugPrint('Subresource error (ignored): ${error.description}');
+                      }
+                    },
+                  ),
+                  if (_progress < 1.0)
+                    Positioned(
+                      top: 0,
+                      left: 0,
+                      right: 0,
+                      child: ClipRRect(
+                        borderRadius: const BorderRadius.only(
+                          topLeft: Radius.circular(16),
+                          topRight: Radius.circular(16),
+                        ),
+                        child: SizedBox(
+                          height: 4,
+                          child: LinearProgressIndicator(
+                            value: _progress,
+                            backgroundColor: Colors.grey[800],
+                            valueColor: AlwaysStoppedAnimation<Color>(
+                              Theme.of(context).colorScheme.primary,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  if (_isLoading && _progress < 0.1)
+                    Container(
+                      decoration: const BoxDecoration(
+                        color: Colors.black,
+                        borderRadius: BorderRadius.only(
+                          topLeft: Radius.circular(16),
+                          topRight: Radius.circular(16),
+                        ),
+                      ),
+                      child: const Center(
+                        child: CircularProgressIndicator(),
+                      ),
+                    ),
+                  if (_errorMessage != null)
+                    Container(
+                      decoration: const BoxDecoration(
+                        color: Colors.black,
+                        borderRadius: BorderRadius.only(
+                          topLeft: Radius.circular(16),
+                          topRight: Radius.circular(16),
+                        ),
+                      ),
+                      padding: const EdgeInsets.all(16),
+                      child: Center(
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Icon(
+                              Icons.error_outline,
+                              color: Theme.of(context).colorScheme.error,
+                              size: 48,
+                            ),
+                            const SizedBox(height: 16),
+                            Text(
+                              'Failed to load page',
+                              style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                                    color: Theme.of(context).colorScheme.error,
+                                  ),
+                            ),
+                            const SizedBox(height: 8),
+                            Text(
+                              _errorMessage!,
+                              textAlign: TextAlign.center,
+                              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                    color: Theme.of(context).colorScheme.error,
+                                  ),
+                            ),
+                            const SizedBox(height: 16),
+                            ElevatedButton.icon(
+                              onPressed: () {
+                                widget.onBrowserClosed(true);
+                                Navigator.of(context).pop();
+                              },
+                              icon: const Icon(Icons.close),
+                              label: const Text('Close'),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/with-flutter/pubspec.lock
+++ b/mobile/with-flutter/pubspec.lock
@@ -36,10 +36,9 @@ packages:
   capsule:
     dependency: "direct main"
     description:
-      name: capsule
-      sha256: "27ae3f8d140543e59963ad03bb53ebe912652556836d8a76e9456748b7f35acd"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../../../flutter-sdk"
+      relative: true
+    source: path
     version: "0.5.0"
   characters:
     dependency: transitive

--- a/mobile/with-flutter/pubspec.yaml
+++ b/mobile/with-flutter/pubspec.yaml
@@ -9,7 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  capsule: 0.5.0
+  capsule:
+    path: ../../../flutter-sdk
   flutter_dotenv: ^5.2.1
   flutter_inappwebview: ^6.1.5
   font_awesome_flutter: ^10.8.0


### PR DESCRIPTION
- Switch to inappwebview widget instead of the ChromeSafarBrowser in the app browser as it creates a bug in iOS with OAuth.
- Added user agent to bypass Google user agent policy